### PR TITLE
Fix building with sandbox enabled

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -21,7 +21,7 @@
 
           installPhase = ''
             runHook preInstall
-            PREFIX=$out ./install
+            PREFIX=$out bash ./install
             runHook postInstall
           '';
 


### PR DESCRIPTION
Building with sandbox fails with the following error:

```
$ sudo nix build --print-build-logs github:neko-kai/claude-code-sandbox --option sandbox true --rebuild
claude-sandbox> Running phase: unpackPhase
claude-sandbox> unpacking source archive /nix/store/car5l68kq13sic0zwlkmh0vb23l6rs8r-z7d05vm4iw18i12d0c6j5pzfb0h35vix-source
claude-sandbox> source root is z7d05vm4iw18i12d0c6j5pzfb0h35vix-source
claude-sandbox> Running phase: patchPhase
claude-sandbox> Running phase: updateAutotoolsGnuConfigScriptsPhase
claude-sandbox> Running phase: configurePhase
claude-sandbox> no configure script, doing nothing
claude-sandbox> Running phase: buildPhase
claude-sandbox> no Makefile or custom buildPhase, doing nothing
claude-sandbox> Running phase: installPhase
claude-sandbox> /nix/store/dnjd7b7v5vyd8g152ziivp2jaz56bb5l-stdenv-darwin/setup: ./install: /usr/bin/env: bad interpreter: Operation not permitted
error: builder for '/nix/store/85xikb9krn3hihsw1rsmjb0gaxd4525g-claude-sandbox-0.1.0.drv' failed with exit code 126;
       last 11 log lines:
       > Running phase: unpackPhase
       > unpacking source archive /nix/store/car5l68kq13sic0zwlkmh0vb23l6rs8r-z7d05vm4iw18i12d0c6j5pzfb0h35vix-source
       > source root is z7d05vm4iw18i12d0c6j5pzfb0h35vix-source
       > Running phase: patchPhase
       > Running phase: updateAutotoolsGnuConfigScriptsPhase
       > Running phase: configurePhase
       > no configure script, doing nothing
       > Running phase: buildPhase
       > no Makefile or custom buildPhase, doing nothing
       > Running phase: installPhase
       > /nix/store/dnjd7b7v5vyd8g152ziivp2jaz56bb5l-stdenv-darwin/setup: ./install: /usr/bin/env: bad interpreter: Operation not permitted
       For full logs, run:
            nix log /nix/store/85xikb9krn3hihsw1rsmjb0gaxd4525g-claude-sandbox-0.1.0.drv
```