### PR TITLE
Allow reading Jujutsu config

### DIFF
--- a/noread.sb
+++ b/noread.sb
@@ -49,6 +49,7 @@
 (allow file-read*
     ;; Git configuration (for commits)
     (subpath (string-append (param "HOME_DIR") "/.config/git"))
+    (subpath (string-append (param "HOME_DIR") "/.config/jj"))
     (literal (string-append (param "HOME_DIR") "/.gitconfig"))
     ;; Nix configuration
     (subpath (string-append (param "HOME_DIR") "/.config/nix"))


### PR DESCRIPTION
Without this PR, I run into:

```
! jj show @-
  ⎿  Internal error: Failed to determine the secure config for a repo
     Caused by:
     1: Cannot access /Users/enzime/.config/jj/repos/d684039800869528748a/metadata.binpb
     2: Operation not permitted (os error 1)
```