### PR TITLE
Allow reading Nix's trusted settings

### DIFF
--- a/noread.sb
+++ b/noread.sb
@@ -53,6 +53,7 @@
     (literal (string-append (param "HOME_DIR") "/.gitconfig"))
     ;; Nix configuration
     (subpath (string-append (param "HOME_DIR") "/.config/nix"))
+    (subpath (string-append (param "HOME_DIR") "/.local/share/nix"))
     ;; Nix profile binaries (symlinks to /nix/store)
     (subpath (string-append (param "HOME_DIR") "/.nix-profile"))
     (subpath (string-append (param "HOME_DIR") "/.local/state/nix"))


### PR DESCRIPTION
I now get this error when trying to run any Nix commands even in flakes without `nixConfig` set:

```
error: getting status of '/Users/enzime/.local/share/nix/trusted-settings.json': Operation not permitted
```